### PR TITLE
Reproduce scroll-region bug on page forms

### DIFF
--- a/resources/js/Pages/Organizations/Edit.vue
+++ b/resources/js/Pages/Organizations/Edit.vue
@@ -28,6 +28,22 @@
           <loading-button :loading="form.processing" class="btn-indigo ml-auto" type="submit">Update Organization</loading-button>
         </div>
       </form>
+      <div class="h-12 border border-red-300 overflow-hidden m-2 mt-10">
+        <div class="overflow-y-scroll h-12" scroll-region>
+          <div class="m-2 border border-green-200">
+            <p>1</p>
+            <p>2</p>
+            <p>3</p>
+            <p>4</p>
+            <p>5</p>
+            <p>6</p>
+            <p>7</p>
+            <p>8</p>
+            <p>9</p>
+            <p>10</p>
+          </div>
+        </div>
+      </div>
     </div>
     <h2 class="mt-12 text-2xl font-bold">Contacts</h2>
     <div class="mt-6 bg-white rounded shadow overflow-x-auto">
@@ -108,7 +124,7 @@ export default {
   },
   methods: {
     update() {
-      this.form.put(`/organizations/${this.organization.id}`)
+      this.form.put(`/organizations/${this.organization.id}`, { preserveState: 'errors', preserveScroll: true })
     },
     destroy() {
       if (confirm('Are you sure you want to delete this organization?')) {

--- a/resources/js/Shared/MainMenu.vue
+++ b/resources/js/Shared/MainMenu.vue
@@ -24,6 +24,22 @@
         <div :class="isUrl('reports') ? 'text-white' : 'text-indigo-300 group-hover:text-white'">Reports</div>
       </Link>
     </div>
+    <div class="h-12 border border-red-300 overflow-hidden">
+      <div class="overflow-y-scroll h-12" scroll-region>
+        <div class="m-2 border border-green-200 text-white">
+          <p>1</p>
+          <p>2</p>
+          <p>3</p>
+          <p>4</p>
+          <p>5</p>
+          <p>6</p>
+          <p>7</p>
+          <p>8</p>
+          <p>9</p>
+          <p>10</p>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
To reproduce:

1. Navigate to Organizations page
2. Click on any organization
3. Scroll inside the scroll region (both in the main menu and below the form)
4. Click Update Organization
5. The scroll region below the form does not preserve its scroll position.